### PR TITLE
Controlled refactor, LookAction input, combat systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2567,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2684,31 @@ checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
 dependencies = [
  "bytemuck",
  "emath",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2869,6 +2942,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -4741,8 +4820,12 @@ dependencies = [
  "bevy_egui",
  "bevy_enhanced_input",
  "bevy_kira_audio",
+ "dirs",
+ "ed25519-dalek",
  "lightyear",
+ "rand 0.8.5",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5394,6 +5477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,6 +5670,16 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5864,11 +5963,22 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -5881,6 +5991,16 @@ dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6034,6 +6154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6442,6 +6573,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ bevy_enhanced_input = {version = "0.22", features = ["serialize"]}
 bevy_egui = "0.39"
 bevy_kira_audio = {version = "0.25", features = ["mp3"]}
 serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0"
+ed25519-dalek = {version = "2", features = ["rand_core"]}
+rand = "0.8"
+dirs = "6"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,146 @@
+use std::fs;
+use std::path::PathBuf;
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use rand::rngs::OsRng;
+
+/// Keypair file format: JSON array of 64 bytes (same as Solana CLI's id.json).
+/// First 32 bytes = secret key, last 32 bytes = public key.
+const KEYPAIR_FILE: &str = "keypair.json";
+const APP_DIR: &str = "anima";
+
+/// Returns the path to ~/.anima/keypair.json (or keypair-{suffix}.json if specified).
+fn keypair_path(suffix: Option<&str>) -> PathBuf {
+    let home = dirs::home_dir().expect("Could not find home directory");
+    let filename = match suffix {
+        Some(s) => format!("keypair-{}.json", s),
+        None => KEYPAIR_FILE.to_string(),
+    };
+    home.join(format!(".{}", APP_DIR)).join(filename)
+}
+
+/// Parse --keypair <suffix> from CLI args.
+pub fn keypair_suffix_from_args() -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    args.windows(2)
+        .find(|w| w[0] == "--keypair")
+        .map(|w| w[1].clone())
+}
+
+/// Load an existing keypair from disk, or generate and save a new one.
+/// Returns (signing_key, public_key_bytes).
+pub fn load_or_create_keypair(suffix: Option<&str>) -> (SigningKey, [u8; 32]) {
+    let path = keypair_path(suffix);
+
+    if path.exists() {
+        let data = fs::read_to_string(&path).expect("Failed to read keypair file");
+        let bytes: Vec<u8> = serde_json::from_str(&data).expect("Failed to parse keypair JSON");
+        assert_eq!(bytes.len(), 64, "Keypair file must be 64 bytes");
+
+        let secret_bytes: [u8; 32] = bytes[..32].try_into().unwrap();
+        let signing_key = SigningKey::from_bytes(&secret_bytes);
+        let pubkey = signing_key.verifying_key().to_bytes();
+
+        bevy::log::info!(
+            "Loaded keypair from {} — pubkey: {}",
+            path.display(),
+            bs58_encode(&pubkey)
+        );
+
+        (signing_key, pubkey)
+    } else {
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pubkey = signing_key.verifying_key().to_bytes();
+
+        // Save in Solana-compatible format: [secret_key(32) ++ public_key(32)]
+        let mut keypair_bytes = Vec::with_capacity(64);
+        keypair_bytes.extend_from_slice(&signing_key.to_bytes());
+        keypair_bytes.extend_from_slice(&pubkey);
+
+        let json = serde_json::to_string(&keypair_bytes).unwrap();
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create .anima directory");
+        }
+        fs::write(&path, &json).expect("Failed to write keypair file");
+
+        bevy::log::info!(
+            "Generated new keypair at {} — pubkey: {}",
+            path.display(),
+            bs58_encode(&pubkey)
+        );
+
+        (signing_key, pubkey)
+    }
+}
+
+/// Derive a deterministic u64 client ID from the public key.
+/// Used as the lightyear client ID for networking.
+pub fn pubkey_to_client_id(pubkey: &[u8; 32]) -> u64 {
+    u64::from_le_bytes(pubkey[..8].try_into().unwrap())
+}
+
+/// Get the public key as a Solana-style base58 address string.
+pub fn pubkey_address(pubkey: &[u8; 32]) -> String {
+    bs58_encode(pubkey)
+}
+
+/// Minimal base58 encoding (Solana address format).
+fn bs58_encode(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+    if bytes.is_empty() {
+        return String::new();
+    }
+
+    // Count leading zeros
+    let leading_zeros = bytes.iter().take_while(|&&b| b == 0).count();
+
+    // Convert to base58
+    let mut digits: Vec<u8> = Vec::new();
+    for &byte in bytes {
+        let mut carry = byte as u32;
+        for digit in digits.iter_mut() {
+            carry += (*digit as u32) << 8;
+            *digit = (carry % 58) as u8;
+            carry /= 58;
+        }
+        while carry > 0 {
+            digits.push((carry % 58) as u8);
+            carry /= 58;
+        }
+    }
+
+    let mut result = String::with_capacity(leading_zeros + digits.len());
+    for _ in 0..leading_zeros {
+        result.push('1');
+    }
+    for &d in digits.iter().rev() {
+        result.push(ALPHABET[d as usize] as char);
+    }
+    result
+}
+
+/// Bevy resource holding the client's identity.
+#[derive(bevy::prelude::Resource)]
+pub struct ClientIdentity {
+    pub signing_key: SigningKey,
+    pub pubkey: [u8; 32],
+    pub client_id: u64,
+    pub address: String,
+}
+
+impl ClientIdentity {
+    pub fn load_or_create() -> Self {
+        let suffix = keypair_suffix_from_args();
+        let (signing_key, pubkey) = load_or_create_keypair(suffix.as_deref());
+        let client_id = pubkey_to_client_id(&pubkey);
+        let address = pubkey_address(&pubkey);
+        Self {
+            signing_key,
+            pubkey,
+            client_id,
+            address,
+        }
+    }
+}

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -18,7 +18,8 @@ use multiplayer::world::{
     spawn_lights, spawn_world_model, update_view_model, WorldModelCamera, DEFAULT_RENDER_LAYER,
     interaction_ui_system, init_replicated_doors, init_replicated_equippables,
     init_replicated_interactables, sync_door_state, sync_equippable_visibility,
-    sync_remote_equipped, sync_remote_orientation,
+    sync_remote_equipped, spawn_tracer, cleanup_tracers,
+    start_jab_animation, animate_jab, LeftHand,
 };
 use multiplayer::{SharedPlugin, FIXED_TIMESTEP_HZ, PROTOCOL_ID, SERVER_PORT};
 
@@ -65,15 +66,20 @@ struct LineGradient(Handle<Image>);
 struct MenuSelection(usize);
 
 fn main() {
+    // Load or generate persistent Ed25519 keypair (~/.anima/keypair.json)
+    let identity = multiplayer::auth::ClientIdentity::load_or_create();
+    info!("Client identity: {} (id={})", identity.address, identity.client_id);
+
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            title: "ANIMA".to_string(),
+            title: format!("ANIMA — {}", &identity.address[..8]),
             ..default()
         }),
         ..default()
     }))
     .insert_resource(ClearColor(Color::BLACK));
+    app.insert_resource(identity);
     app.add_plugins(EguiPlugin::default());
     app.add_plugins(AudioPlugin);
     app.add_plugins(ClientPlugins {
@@ -105,14 +111,12 @@ fn main() {
     app.add_systems(
         Update,
         (
-            mouse_look,
-            sync_player_yaw,
+            sync_camera_pitch,
             grab_mouse,
             change_fov,
             update_view_model,
             interaction_ui_system,
             sync_door_state,
-            sync_remote_orientation,
             init_replicated_doors,
             init_replicated_equippables,
             init_replicated_interactables,
@@ -127,15 +131,22 @@ fn main() {
     );
     app.add_systems(
         FixedPreUpdate,
-        pre_rotate_move_input
+        (pre_rotate_move_input, gate_look_on_cursor)
             .after(EnhancedInputSystems::Update)
             .before(lightyear::prelude::client::input::InputSystems::BufferClientInputs)
             .run_if(not(lightyear::prelude::is_in_rollback))
             .run_if(in_state(AppState::InGame)),
     );
 
+    app.add_systems(
+        Update,
+        (cleanup_tracers, animate_jab, health_hud, log_health_changes).run_if(in_state(AppState::InGame)),
+    );
+
     app.add_observer(on_predicted_spawn);
     app.add_observer(on_interpolated_spawn);
+    app.add_observer(spawn_tracer);
+    app.add_observer(start_jab_animation);
     app.run();
 }
 
@@ -693,21 +704,18 @@ fn despawn_menu(
     }
 }
 
-fn connect_to_server(mut commands: Commands) {
+fn connect_to_server(mut commands: Commands, identity: Res<multiplayer::auth::ClientIdentity>) {
     let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), SERVER_PORT);
     let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0);
 
-    let client_id = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-
     let auth = Authentication::Manual {
         server_addr,
-        client_id,
+        client_id: identity.client_id,
         private_key: [0; 32],
         protocol_id: PROTOCOL_ID,
     };
+
+    info!("Connecting as {} (id={})", identity.address, identity.client_id);
 
     let netcode_config = NetcodeConfig {
         client_timeout_secs: 120,
@@ -734,49 +742,118 @@ fn connect_to_server(mut commands: Commands) {
         .id();
 
     commands.trigger(Connect { entity: client_entity });
-    info!("Connecting to server at {} as client {}", server_addr, client_id);
 }
 
 // ========================================
 // Player spawn
 // ========================================
 
-/// Local player: predicted entity owned by this client.
+/// Log health changes for debugging.
+fn log_health_changes(
+    query: Query<(Entity, &PlayerHealth, Has<Controlled>), Changed<PlayerHealth>>,
+) {
+    for (entity, health, is_local) in query.iter() {
+        let tag = if is_local { "LOCAL" } else { "REMOTE" };
+        info!("[HEALTH] {} {:?} health={}", tag, entity, health.0);
+    }
+}
+
+/// HUD: health bar at the bottom-center of the screen.
+fn health_hud(
+    mut contexts: EguiContexts,
+    player_query: Query<&PlayerHealth, With<Controlled>>,
+) {
+    let Ok(health) = player_query.single() else { return; };
+    let Ok(ctx) = contexts.ctx_mut() else { return; };
+
+    let screen = ctx.screen_rect();
+    let bar_w = 200.0;
+    let bar_h = 16.0;
+    let bar_x = (screen.width() - bar_w) / 2.0;
+    let bar_y = screen.height() - 50.0;
+
+    egui::Area::new(egui::Id::new("health_hud"))
+        .fixed_pos(egui::pos2(bar_x, bar_y))
+        .order(egui::Order::Foreground)
+        .interactable(false)
+        .show(ctx, |ui| {
+            let hp = health.0.max(0) as f32;
+            let pct = (hp / 100.0).clamp(0.0, 1.0);
+
+            // Bar color: green → yellow → red as health drops
+            let color = if pct > 0.5 {
+                egui::Color32::from_rgb(50, 200, 80)
+            } else if pct > 0.25 {
+                egui::Color32::from_rgb(220, 180, 30)
+            } else {
+                egui::Color32::from_rgb(220, 40, 40)
+            };
+
+            let (rect, _) = ui.allocate_exact_size(
+                egui::vec2(bar_w, bar_h),
+                egui::Sense::hover(),
+            );
+
+            // Background
+            ui.painter().rect_filled(rect, 4.0, egui::Color32::from_rgba_unmultiplied(0, 0, 0, 160));
+            // Health fill
+            let fill_rect = egui::Rect::from_min_size(
+                rect.min,
+                egui::vec2(bar_w * pct, bar_h),
+            );
+            ui.painter().rect_filled(fill_rect, 4.0, color);
+            // Border
+            ui.painter().rect_stroke(rect, 4.0, egui::Stroke::new(1.0, egui::Color32::from_white_alpha(80)), egui::StrokeKind::Outside);
+            // Text
+            ui.painter().text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                format!("{}", health.0.max(0)),
+                chakra(12.0),
+                egui::Color32::WHITE,
+            );
+        });
+}
+
+/// Predicted entity spawned — fires for our own player (which has Controlled).
+/// Sets up physics for ALL predicted entities; cameras/input only for controlled ones.
 fn on_predicted_spawn(
     trigger: On<Add, (PlayerId, Predicted)>,
-    existing_local: Query<(), With<LocalPlayer>>,
-    query: Query<&PlayerId>,
+    query: Query<(&PlayerId, Has<Controlled>)>,
     position_query: Query<&avian3d::prelude::Position>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let entity = trigger.entity;
-    let Ok(player_id) = query.get(entity) else {
+    let Ok((player_id, is_controlled)) = query.get(entity) else {
         return;
     };
 
-    if existing_local.get(entity).is_ok() {
-        return;
-    }
-    info!("Local player spawned: {:?}", entity);
+    info!("[SPAWN] Predicted player {:?} (id={}) controlled={}", entity, player_id.0, is_controlled);
 
     let spawn_transform = position_query
         .get(entity)
         .map(|p| Transform::from_translation(p.0))
         .unwrap_or(Transform::from_translation(PLAYER_SPAWN_POS));
 
-    let arm = meshes.add(Cuboid::new(0.1, 0.1, 0.5));
-    let arm_material = materials.add(Color::from(tailwind::TEAL_200));
-
+    // All predicted entities get physics + basic components
     commands.entity(entity).insert((
         player_physics_bundle(),
-        LocalPlayer,
-        CameraSensitivity::default(),
         Player { id: player_id.0 },
         spawn_transform,
         Visibility::default(),
     ));
+
+    // Only our controlled entity gets cameras, input bindings, and view model
+    if !is_controlled {
+        return;
+    }
+
+    commands.entity(entity).insert(CameraSensitivity::default());
+
+    let arm = meshes.add(Cuboid::new(0.1, 0.1, 0.5));
+    let arm_material = materials.add(Color::from(tailwind::TEAL_200));
 
     commands.entity(entity).with_children(|parent| {
         parent.spawn((
@@ -800,12 +877,22 @@ fn on_predicted_spawn(
             }),
             RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
         ));
+        // Right hand (arm)
         parent.spawn((
             Mesh3d(arm),
-            MeshMaterial3d(arm_material),
+            MeshMaterial3d(arm_material.clone()),
             Transform::from_xyz(0.2, -0.1, -0.25),
             RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
             NotShadowCaster,
+        ));
+        // Left hand — starts off-screen, animates in on jab
+        parent.spawn((
+            Mesh3d(meshes.add(Cuboid::new(0.12, 0.12, 0.4))),
+            MeshMaterial3d(arm_material),
+            Transform::from_xyz(-0.8, -0.3, -0.2),
+            RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
+            NotShadowCaster,
+            LeftHand,
         ));
     });
 
@@ -826,12 +913,28 @@ fn on_predicted_spawn(
     ));
     commands.spawn((
         ActionOf::<PlayerContext>::new(entity),
+        Action::<DropAction>::new(),
+        Bindings::spawn(Spawn(Binding::from(KeyCode::KeyG))),
+    ));
+    commands.spawn((
+        ActionOf::<PlayerContext>::new(entity),
+        Action::<JabAction>::new(),
+        Bindings::spawn(Spawn(Binding::from(KeyCode::KeyQ))),
+    ));
+    commands.spawn((
+        ActionOf::<PlayerContext>::new(entity),
         Action::<PrimaryAction>::new(),
         Bindings::spawn(Spawn(Binding::from(MouseButton::Left))),
+    ));
+    commands.spawn((
+        ActionOf::<PlayerContext>::new(entity),
+        Action::<LookAction>::new(),
+        Bindings::spawn(Spawn(Binding::mouse_motion())),
     ));
 }
 
 /// Remote player: interpolated entity — smooth, slightly delayed, no rubberbanding.
+/// Lightyear never adds Interpolated to our own entity, so no guards needed.
 fn on_interpolated_spawn(
     trigger: On<Add, (PlayerId, Interpolated)>,
     query: Query<&PlayerId>,
@@ -844,7 +947,7 @@ fn on_interpolated_spawn(
         return;
     };
 
-    info!("Remote player spawned (interpolated): {:?} (id={})", entity, player_id.0);
+    info!("[SPAWN] Remote interpolated player spawned: {:?} (id={})", entity, player_id.0);
 
     commands.entity(entity).insert((
         player_physics_bundle(),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -22,6 +22,10 @@ fn main() {
                 primary_cursor_options: None,
                 exit_condition: bevy::window::ExitCondition::DontExit,
                 close_when_requested: false,
+            })
+            .set(bevy::log::LogPlugin {
+                filter: "bevy_enhanced_input::action::fns=error".into(),
+                ..default()
             }),
     );
     app.add_plugins(bevy::app::ScheduleRunnerPlugin::run_loop(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use lightyear::avian3d::plugin::AvianReplicationMode;
 use lightyear::avian3d::prelude::*;
 
+pub mod auth;
 pub mod player;
 pub mod protocol;
 pub mod world;
@@ -49,17 +50,22 @@ impl Plugin for SharedPlugin {
         // Kinematic character controller: gravity, ground detection, move-and-slide.
         app.add_systems(FixedUpdate, player::character_controller);
 
+        // Sync PlayerYaw+PlayerPitch → Rotation for all players. Runs on both client (prediction)
+        // and server (authority). Lightyear's Avian plugin syncs Rotation → Transform for rendering.
+        app.add_systems(FixedUpdate, player::sync_rotation_from_yaw);
+
         // Reset stale mining state (detects when player stops holding mine button)
         app.add_systems(FixedUpdate, world::reset_stale_mining);
 
         // Shared observers (fire on both client predicted + server authoritative via BEI replay)
+        app.add_observer(player::shared_look);
         app.add_observer(player::shared_movement);
         app.add_observer(player::shared_jump);
         app.add_observer(world::shared_door_interact);
         app.add_observer(world::shared_equip_interact);
+        app.add_observer(world::shared_drop);
+        app.add_observer(world::shared_jab);
         app.add_observer(world::shared_primary_action);
 
-        // Diagnostic logging
-        app.add_systems(Update, player::log_player_state);
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -8,7 +8,10 @@ use bevy::{
 };
 use bevy_enhanced_input::prelude::*;
 
-use crate::protocol::{CharacterVelocity, JumpAction, MoveAction, PlayerContext, PlayerEquipped, PlayerHealth, PlayerPitch};
+use avian3d::prelude::Rotation;
+use lightyear::prelude::Controlled;
+
+use crate::protocol::{CharacterVelocity, JumpAction, LookAction, MoveAction, PlayerContext, PlayerEquipped, PlayerHealth, PlayerPitch, PlayerYaw};
 
 pub const PLAYER_MOVE_SPEED: f32 = 7.0;
 pub const JUMP_SPEED: f32 = 10.0;
@@ -54,9 +57,6 @@ impl Default for CursorState {
     }
 }
 
-/// Marker for the local (predicted) player entity
-#[derive(Component)]
-pub struct LocalPlayer;
 
 // --- Shared Bundles ---
 // These ensure server and client have identical physics/gameplay components.
@@ -340,25 +340,55 @@ pub fn log_player_state(
     }
 }
 
+// --- Shared Systems ---
+
+/// Shared observer: applies mouse look deltas to PlayerYaw/PlayerPitch.
+/// Runs on both client (prediction) and server (authority) via BEI input replication.
+/// This is how yaw/pitch reach the server — through the input system, not component replication.
+pub fn shared_look(
+    trigger: On<Fire<LookAction>>,
+    mut query: Query<(&mut PlayerYaw, &mut PlayerPitch)>,
+) {
+    let delta = trigger.value;
+    if delta == Vec2::ZERO {
+        return;
+    }
+
+    let Ok((mut yaw, mut pitch)) = query.get_mut(trigger.context) else {
+        return;
+    };
+
+    yaw.0 += -delta.x * 0.003;
+    const PITCH_LIMIT: f32 = FRAC_PI_2 - 0.01;
+    pitch.0 = (pitch.0 + -delta.y * 0.002).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+}
+
+/// Shared system: syncs PlayerYaw + PlayerPitch → Rotation so lightyear replicates
+/// both facing direction and pitch tilt. Runs in FixedUpdate on both client and server.
+/// Remote players display correct pitch tilt via the replicated Rotation.
+pub fn sync_rotation_from_yaw(
+    mut query: Query<(&PlayerYaw, &PlayerPitch, &mut Rotation), With<PlayerContext>>,
+) {
+    for (yaw, pitch, mut rot) in query.iter_mut() {
+        rot.0 = Quat::from_euler(EulerRot::YXZ, yaw.0, pitch.0, 0.0);
+    }
+}
+
 // --- Client-Only Systems ---
 
 /// Pre-rotate MoveAction's raw WASD Vec2 by camera yaw so the value sent to the
 /// server is already in world-space. Runs between BEI Update and BufferClientInputs.
 pub fn pre_rotate_move_input(
-    player_query: Query<(&Children, Entity), With<LocalPlayer>>,
-    camera_query: Query<&Transform, With<crate::world::WorldModelCamera>>,
+    player_query: Query<&PlayerYaw, With<Controlled>>,
     mut action_query: Query<
         (&ActionOf<crate::protocol::PlayerContext>, &mut ActionValue),
         With<Action<MoveAction>>,
     >,
 ) {
-    let Ok((children, _player_entity)) = player_query.single() else {
+    let Ok(player_yaw) = player_query.single() else {
         return;
     };
-    let Some(cam_transform) = children.iter().find_map(|c| camera_query.get(c).ok()) else {
-        return;
-    };
-    let (yaw, _, _) = cam_transform.rotation.to_euler(EulerRot::YXZ);
+    let yaw = player_yaw.0;
 
     for (_action_of, mut value) in action_query.iter_mut() {
         if let ActionValue::Axis2D(v) = *value {
@@ -373,55 +403,35 @@ pub fn pre_rotate_move_input(
     }
 }
 
-/// Sync camera yaw and pitch to replicated components so the server and other clients
-/// know our facing direction.
-pub fn sync_player_yaw(
-    player_query: Query<(&Children, Entity), With<LocalPlayer>>,
-    camera_query: Query<&Transform, With<crate::world::WorldModelCamera>>,
-    mut yaw_query: Query<(&mut crate::protocol::PlayerYaw, &mut PlayerPitch)>,
+/// Client-only: zeros LookAction when cursor is unlocked (e.g. Escape pressed).
+/// Prevents mouse deltas from being sent to the server when the player isn't in control.
+/// Runs in FixedPreUpdate between BEI Update and BufferClientInputs.
+pub fn gate_look_on_cursor(
+    cursor_state: Res<CursorState>,
+    mut action_query: Query<&mut ActionValue, With<Action<crate::protocol::LookAction>>>,
 ) {
-    let Ok((children, entity)) = player_query.single() else {
+    if cursor_state.locked {
         return;
-    };
-    let Some(cam_transform) = children.iter().find_map(|c| camera_query.get(c).ok()) else {
-        return;
-    };
-    let (yaw, pitch, _) = cam_transform.rotation.to_euler(EulerRot::YXZ);
-    if let Ok((mut player_yaw, mut player_pitch)) = yaw_query.get_mut(entity) {
-        player_yaw.0 = yaw;
-        player_pitch.0 = pitch;
+    }
+    for mut value in action_query.iter_mut() {
+        *value = ActionValue::Axis2D(Vec2::ZERO);
     }
 }
 
-/// Mouse look: rotates the camera child entity (pitch + yaw). Visual only.
-pub fn mouse_look(
-    accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
-    player_query: Query<&Children, With<LocalPlayer>>,
+/// Client-only: ensures the camera child has identity rotation.
+/// The parent's Rotation now includes both yaw and pitch (via sync_rotation_from_yaw),
+/// so the camera child inherits the correct orientation automatically.
+pub fn sync_camera_pitch(
+    player_query: Query<&Children, With<Controlled>>,
     mut camera_query: Query<&mut Transform, With<crate::world::WorldModelCamera>>,
-    cursor_state: Res<CursorState>,
 ) {
-    if !cursor_state.locked {
-        return;
-    }
-
-    let delta = accumulated_mouse_motion.delta;
-    if delta == Vec2::ZERO {
-        return;
-    }
-
     let Ok(children) = player_query.single() else {
         return;
     };
 
     for child in children.iter() {
         if let Ok(mut cam_transform) = camera_query.get_mut(child) {
-            let (mut yaw, mut pitch, _roll) = cam_transform.rotation.to_euler(EulerRot::YXZ);
-
-            yaw += -delta.x * 0.003;
-            const PITCH_LIMIT: f32 = FRAC_PI_2 - 0.01;
-            pitch = (pitch + -delta.y * 0.002).clamp(-PITCH_LIMIT, PITCH_LIMIT);
-
-            cam_transform.rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch, 0.0);
+            cam_transform.rotation = Quat::IDENTITY;
         }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,5 @@
 use avian3d::prelude::*;
+use bevy::math::VectorSpace;
 use bevy::prelude::*;
 use bevy_enhanced_input::prelude::*;
 use lightyear::prelude::input::bei::InputPlugin;
@@ -13,11 +14,44 @@ use serde::{Deserialize, Serialize};
 pub struct PlayerId(pub u64);
 
 /// The player's camera yaw, replicated so the server can compute camera-relative movement.
-#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
 pub struct PlayerYaw(pub f32);
 
+// VectorSpace impls for PlayerYaw/PlayerPitch so lightyear can interpolate them on remote clients.
+macro_rules! impl_vector_space_f32 {
+    ($T:ident) => {
+        impl std::ops::Add for $T {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self { Self(self.0 + rhs.0) }
+        }
+        impl std::ops::Sub for $T {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self { Self(self.0 - rhs.0) }
+        }
+        impl std::ops::Mul<f32> for $T {
+            type Output = Self;
+            fn mul(self, rhs: f32) -> Self { Self(self.0 * rhs) }
+        }
+        impl std::ops::Div<f32> for $T {
+            type Output = Self;
+            fn div(self, rhs: f32) -> Self { Self(self.0 / rhs) }
+        }
+        impl std::ops::Neg for $T {
+            type Output = Self;
+            fn neg(self) -> Self { Self(-self.0) }
+        }
+        impl bevy::math::VectorSpace for $T {
+            type Scalar = f32;
+            const ZERO: Self = Self(0.0);
+        }
+    };
+}
+
+impl_vector_space_f32!(PlayerYaw);
+impl_vector_space_f32!(PlayerPitch);
+
 /// The player's camera pitch, replicated so remote clients can tilt the player model.
-#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
 pub struct PlayerPitch(pub f32);
 
 /// Player velocity managed by our kinematic character controller.
@@ -49,10 +83,27 @@ pub struct JumpAction;
 #[action_output(bool)]
 pub struct InteractAction;
 
+/// G → drop equipped item
+#[derive(Debug, InputAction)]
+#[action_output(bool)]
+pub struct DropAction;
+
+/// Q → left hand jab (melee)
+#[derive(Debug, InputAction)]
+#[action_output(bool)]
+pub struct JabAction;
+
 /// Left click → primary action (mine, shoot, etc. depending on equipped item)
 #[derive(Debug, InputAction)]
 #[action_output(bool)]
 pub struct PrimaryAction;
+
+/// Mouse motion → look delta (Vec2: x = yaw delta, y = pitch delta).
+/// Replicated to server via lightyear's BEI input system so the server
+/// knows the player's facing direction for hit detection.
+#[derive(Debug, InputAction)]
+#[action_output(Vec2)]
+pub struct LookAction;
 
 /// Tracks which tool a player has equipped. Replicated so the server
 /// can validate mining and other players can see held items.
@@ -85,39 +136,64 @@ impl Plugin for ProtocolPlugin {
         app.register_input_action::<MoveAction>();
         app.register_input_action::<JumpAction>();
         app.register_input_action::<InteractAction>();
+        app.register_input_action::<DropAction>();
+        app.register_input_action::<JabAction>();
         app.register_input_action::<PrimaryAction>();
+        app.register_input_action::<LookAction>();
 
         // Replicated components
         app.register_component::<PlayerId>();
         app.register_component::<PlayerYaw>()
-            .add_prediction();
+            .add_prediction()
+            .add_linear_interpolation();
         app.register_component::<PlayerPitch>()
-            .add_prediction();
+            .add_prediction()
+            .add_linear_interpolation();
         app.register_component::<PlayerEquipped>()
             .add_prediction();
         app.register_component::<PlayerHealth>();
 
-        // Avian3d physics components with prediction + interpolation
-        // Matches lightyear FPS example: enable_correction() lets lightyear handle
-        // smooth corrections on Transform directly (via PositionButInterpolateTransform mode).
+        // Avian3d physics components with prediction + interpolation.
+        // enable_correction() lets lightyear handle smooth corrections on Transform
+        // directly (via PositionButInterpolateTransform mode).
+        // add_should_rollback() prevents unnecessary rollbacks from floating-point noise.
         app.register_component::<Position>()
             .add_prediction()
+            .add_should_rollback(position_should_rollback)
             .add_linear_interpolation()
             .enable_correction();
 
         app.register_component::<Rotation>()
             .add_prediction()
+            .add_should_rollback(rotation_should_rollback)
             .add_linear_interpolation()
             .enable_correction();
 
         // Our kinematic velocity (replaces Avian's LinearVelocity for players)
         app.register_component::<CharacterVelocity>()
-            .add_prediction();
+            .add_prediction()
+            .add_should_rollback(velocity_should_rollback);
 
         // World object components — replicated, server-authoritative (no prediction)
         app.register_component::<crate::world::DoorState>();
         app.register_component::<crate::world::Equippable>();
         app.register_component::<crate::world::Interactable>();
     }
+}
+
+// --- Rollback thresholds ---
+// Prevent unnecessary rollbacks from floating-point noise.
+// Only rollback if the server/client values differ by more than a small threshold.
+
+fn position_should_rollback(this: &Position, that: &Position) -> bool {
+    (this.0 - that.0).length() >= 0.01
+}
+
+fn rotation_should_rollback(this: &Rotation, that: &Rotation) -> bool {
+    this.angle_between(*that) >= 0.01
+}
+
+fn velocity_should_rollback(this: &CharacterVelocity, that: &CharacterVelocity) -> bool {
+    (this.0 - that.0).length() >= 0.01
 }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -8,7 +8,7 @@ use lightyear::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::player::VIEW_MODEL_RENDER_LAYER;
-use crate::protocol::{InteractAction, PrimaryAction, PlayerEquipped, PlayerHealth, PlayerPitch, PlayerYaw};
+use crate::protocol::{DropAction, InteractAction, JabAction, PrimaryAction, PlayerEquipped, PlayerHealth, PlayerPitch, PlayerYaw};
 
 #[derive(Debug, Component)]
 pub struct WorldModelCamera;
@@ -23,12 +23,219 @@ pub struct Equippable {
     pub model_path: String,
     pub interaction_distance: f32,
     pub scale: f32,
+    /// Muzzle offset in camera-local space (where the barrel tip is).
+    /// For guns this is where tracers originate. None for non-guns.
+    pub muzzle_offset: Option<[f32; 3]>,
 }
 
 /// Component for the currently equipped view model (client-only).
 #[derive(Component)]
 pub struct EquippedItem {
     pub name: String,
+}
+
+/// Marker for bullet tracer meshes — despawns after a short lifetime.
+#[derive(Component)]
+pub struct BulletTracer {
+    pub spawn_time: f32,
+    pub lifetime: f32,
+}
+
+/// Event fired when a shot happens — client uses this to spawn visual tracer.
+#[derive(Event)]
+pub struct ShotFired {
+    pub muzzle: Vec3,
+    pub hit_point: Vec3,
+}
+
+/// Client-only observer: spawns a red tracer mesh when a shot is fired.
+pub fn spawn_tracer(
+    trigger: On<ShotFired>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    time: Res<Time>,
+) {
+    let shot = trigger.event();
+    let diff = shot.hit_point - shot.muzzle;
+    let length = diff.length();
+    let dir = diff / length;
+    let midpoint = shot.muzzle + dir * (length / 2.0);
+
+    // Cylinder extends along local Y — rotate so Y aligns with shot direction
+    let rotation = Quat::from_rotation_arc(Vec3::Y, dir);
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cylinder::new(0.01, length))),
+        MeshMaterial3d(materials.add(StandardMaterial {
+            base_color: Color::srgb(1.0, 0.1, 0.1),
+            emissive: bevy::color::LinearRgba::new(5.0, 0.2, 0.2, 1.0),
+            unlit: true,
+            ..default()
+        })),
+        Transform::from_translation(midpoint).with_rotation(rotation),
+        BulletTracer {
+            spawn_time: time.elapsed_secs(),
+            lifetime: 0.08,
+        },
+    ));
+}
+
+/// Client-only: despawns tracers after their lifetime expires.
+pub fn cleanup_tracers(
+    query: Query<(Entity, &BulletTracer)>,
+    time: Res<Time>,
+    mut commands: Commands,
+) {
+    let now = time.elapsed_secs();
+    for (entity, tracer) in query.iter() {
+        if now - tracer.spawn_time > tracer.lifetime {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+// ========================================
+// Jab (melee) system
+// ========================================
+
+const JAB_DAMAGE: i32 = 15;
+const JAB_RANGE: f32 = 2.5;
+const JAB_COOLDOWN: f32 = 0.4;
+const JAB_DURATION: f32 = 0.3;
+
+/// Marker for the left hand mesh used for jab animation.
+#[derive(Component)]
+pub struct LeftHand;
+
+/// Tracks the jab animation state. Added to the LeftHand entity when jabbing.
+#[derive(Component)]
+pub struct JabAnimation {
+    pub start_time: f32,
+}
+
+/// Shared observer: jab melee attack — short range punch, server applies damage.
+pub fn shared_jab(
+    trigger: On<Fire<JabAction>>,
+    player_query: Query<(&Position, &PlayerYaw, &PlayerPitch, Has<Predicted>)>,
+    mut health_query: Query<(Entity, &mut PlayerHealth, &Position)>,
+    spatial_query: SpatialQuery,
+    mut commands: Commands,
+    mut last_jab: Local<f32>,
+    time: Res<Time>,
+) {
+    let Ok((player_pos, yaw, pitch, is_predicted)) = player_query.get(trigger.context) else {
+        return;
+    };
+
+    let current = time.elapsed_secs();
+    if current - *last_jab < JAB_COOLDOWN {
+        return;
+    }
+    *last_jab = current;
+
+    let eye_pos = player_pos.0 + Vec3::Y * 0.8;
+    let ray_dir = Quat::from_euler(EulerRot::YXZ, yaw.0, pitch.0, 0.0) * Vec3::NEG_Z;
+    let filter = SpatialQueryFilter::from_excluded_entities([trigger.context]);
+
+    info!(
+        "[JAB] Punch! pos={:?} dir={:?} predicted={}",
+        eye_pos, ray_dir, is_predicted
+    );
+
+    if let Some(hit) = spatial_query.cast_ray(
+        eye_pos,
+        Dir3::new(ray_dir).unwrap_or(Dir3::NEG_Z),
+        JAB_RANGE,
+        true,
+        &filter,
+    ) {
+        info!("[JAB] Hit entity {:?} at distance {:.1}", hit.entity, hit.distance);
+        if !is_predicted {
+            if let Ok((_entity, mut health, _pos)) = health_query.get_mut(hit.entity) {
+                health.0 -= JAB_DAMAGE;
+                info!("[JAB] {} damage applied, health now: {}", JAB_DAMAGE, health.0);
+            } else {
+                info!("[JAB] Hit entity {:?} but it has no PlayerHealth", hit.entity);
+            }
+        }
+    } else {
+        info!("[JAB] Miss — no hit within range {}", JAB_RANGE);
+    }
+
+    // Trigger animation event (client picks this up)
+    commands.trigger(JabFired);
+}
+
+/// Event for client-side jab animation.
+#[derive(Event)]
+pub struct JabFired;
+
+/// Client-only observer: starts the jab animation on the left hand.
+pub fn start_jab_animation(
+    _trigger: On<JabFired>,
+    hand_query: Query<Entity, With<LeftHand>>,
+    mut commands: Commands,
+    time: Res<Time>,
+) {
+    let Ok(hand) = hand_query.single() else { return; };
+    // Insert/overwrite animation component to restart
+    commands.entity(hand).insert(JabAnimation {
+        start_time: time.elapsed_secs(),
+    });
+}
+
+/// Client-only: animates the left hand during a jab.
+/// Slides in from off-screen left, punches forward, retracts.
+pub fn animate_jab(
+    mut hand_query: Query<(&mut Transform, &JabAnimation, Entity), With<LeftHand>>,
+    time: Res<Time>,
+    mut commands: Commands,
+) {
+    let Ok((mut transform, anim, entity)) = hand_query.single_mut() else { return; };
+
+    let elapsed = time.elapsed_secs() - anim.start_time;
+    let t = (elapsed / JAB_DURATION).clamp(0.0, 1.0);
+
+    if t >= 1.0 {
+        // Animation done — return to rest position (off-screen)
+        transform.translation = Vec3::new(-0.8, -0.3, -0.2);
+        commands.entity(entity).remove::<JabAnimation>();
+        return;
+    }
+
+    // Three-phase animation using smoothstep:
+    // 0.0–0.3: slide in from left
+    // 0.3–0.6: punch forward
+    // 0.6–1.0: retract back out
+    let (x, y, z) = if t < 0.3 {
+        // Slide in: (-0.8, -0.3, -0.2) → (-0.25, -0.15, -0.3)
+        let p = smoothstep(t / 0.3);
+        lerp3((-0.8, -0.3, -0.2), (-0.25, -0.15, -0.3), p)
+    } else if t < 0.6 {
+        // Punch forward: (-0.25, -0.15, -0.3) → (-0.15, -0.1, -0.7)
+        let p = smoothstep((t - 0.3) / 0.3);
+        lerp3((-0.25, -0.15, -0.3), (-0.15, -0.1, -0.7), p)
+    } else {
+        // Retract: (-0.15, -0.1, -0.7) → (-0.8, -0.3, -0.2)
+        let p = smoothstep((t - 0.6) / 0.4);
+        lerp3((-0.15, -0.1, -0.7), (-0.8, -0.3, -0.2), p)
+    };
+
+    transform.translation = Vec3::new(x, y, z);
+}
+
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+fn lerp3(a: (f32, f32, f32), b: (f32, f32, f32), t: f32) -> (f32, f32, f32) {
+    (
+        a.0 + (b.0 - a.0) * t,
+        a.1 + (b.1 - a.1) * t,
+        a.2 + (b.2 - a.2) * t,
+    )
 }
 
 /// Component for objects that can be interacted with using tools.
@@ -413,6 +620,7 @@ pub fn spawn_server_interactive_objects(mut commands: Commands) {
             model_path: "dirty-pickaxe.glb".to_string(),
             interaction_distance: 2.0,
             scale: 1.8,
+            muzzle_offset: None,
         },
         Name::new("Pickaxe"),
         Replicate::to_clients(NetworkTarget::All),
@@ -430,6 +638,9 @@ pub fn spawn_server_interactive_objects(mut commands: Commands) {
             model_path: "ak47.glb".to_string(),
             interaction_distance: 2.0,
             scale: 1.8,
+            // Muzzle tip in camera-local space: gun at (0.2, -0.15, -0.4),
+            // barrel extends ~0.5 along -Z at scale 1.0
+            muzzle_offset: Some([0.2, -0.1, -0.9]),
         },
         Name::new("AK47"),
         Replicate::to_clients(NetworkTarget::All),
@@ -613,7 +824,7 @@ pub struct RemoteEquippedItem;
 pub fn sync_remote_equipped(
     changed_query: Query<
         (Entity, &PlayerEquipped),
-        (Changed<PlayerEquipped>, Without<crate::player::LocalPlayer>),
+        (Changed<PlayerEquipped>, Without<lightyear::prelude::Controlled>),
     >,
     children_query: Query<&Children>,
     remote_item_query: Query<Entity, With<RemoteEquippedItem>>,
@@ -656,18 +867,6 @@ pub fn sync_remote_equipped(
     }
 }
 
-/// Client-only: rotates remote player capsules based on their replicated yaw and pitch.
-pub fn sync_remote_orientation(
-    mut query: Query<
-        (&PlayerYaw, &PlayerPitch, &mut Transform),
-        (Without<crate::player::LocalPlayer>, With<crate::player::Player>),
-    >,
-) {
-    for (yaw, pitch, mut transform) in query.iter_mut() {
-        // Yaw rotates the whole body, pitch tilts it forward/back
-        transform.rotation = Quat::from_euler(EulerRot::YXZ, yaw.0, pitch.0 * 0.5, 0.0);
-    }
-}
 
 // ========================================
 // Shared observers — run on both client + server via BEI input replay
@@ -701,19 +900,16 @@ pub fn shared_door_interact(
     }
 }
 
-/// Shared observer: equip/unequip items when player presses E within range.
-/// Idempotent: if already holding the nearby item, do nothing.
-/// On drop: moves the world entity Position to the player's location (replicates).
+/// Shared observer: equip items when player presses E within range.
 pub fn shared_equip_interact(
     trigger: On<Fire<InteractAction>>,
     mut player_query: Query<(&Position, &mut PlayerEquipped)>,
-    mut equippable_query: Query<(Entity, &mut Position, &Equippable), Without<PlayerEquipped>>,
+    equippable_query: Query<(Entity, &Position, &Equippable), Without<PlayerEquipped>>,
 ) {
     let Ok((player_pos, mut equipped)) = player_query.get_mut(trigger.context) else {
         return;
     };
 
-    // Find closest equippable item within range
     let mut closest: Option<(Entity, f32, String)> = None;
     for (entity, eq_pos, equippable) in equippable_query.iter() {
         let dist = player_pos.0.distance(eq_pos.0);
@@ -725,24 +921,33 @@ pub fn shared_equip_interact(
     }
 
     if let Some((_, _, name)) = closest {
-        // Already holding this item — do nothing (idempotent)
         if equipped.0.as_ref() == Some(&name) {
             return;
         }
         info!("Equipped {}", name);
         equipped.0 = Some(name);
-    } else if equipped.0.is_some() {
-        // No item nearby — drop what we're holding
-        let dropped_name = equipped.0.as_ref().unwrap().clone();
-        info!("Dropped {}", dropped_name);
-        equipped.0 = None;
+    }
+}
 
-        // Move the dropped item to player position (Position replicates to all clients)
-        for (_, mut eq_pos, equippable) in equippable_query.iter_mut() {
-            if equippable.name == dropped_name {
-                eq_pos.0 = player_pos.0 + Vec3::new(0.0, -0.5, 0.0);
-                break;
-            }
+/// Shared observer: drop equipped item when player presses G.
+pub fn shared_drop(
+    trigger: On<Fire<DropAction>>,
+    mut player_query: Query<(&Position, &mut PlayerEquipped)>,
+    mut equippable_query: Query<(Entity, &mut Position, &Equippable), Without<PlayerEquipped>>,
+) {
+    let Ok((player_pos, mut equipped)) = player_query.get_mut(trigger.context) else {
+        return;
+    };
+
+    let Some(dropped_name) = equipped.0.take() else {
+        return;
+    };
+    info!("Dropped {}", dropped_name);
+
+    for (_, mut eq_pos, equippable) in equippable_query.iter_mut() {
+        if equippable.name == dropped_name {
+            eq_pos.0 = player_pos.0 + Vec3::new(0.0, -0.5, 0.0);
+            break;
         }
     }
 }
@@ -757,7 +962,8 @@ pub fn shared_primary_action(
     trigger: On<Fire<PrimaryAction>>,
     player_query: Query<(&Position, &PlayerYaw, &PlayerPitch, &PlayerEquipped, Has<Predicted>)>,
     mut interactables_query: Query<(Entity, &Position, &mut Interactable)>,
-    mut health_query: Query<(Entity, &mut PlayerHealth, &Position), Without<PlayerEquipped>>,
+    mut health_query: Query<(Entity, &mut PlayerHealth, &Position)>,
+    equippable_query: Query<&Equippable>,
     spatial_query: SpatialQuery,
     mut commands: Commands,
     mut last_shot: Local<f32>,
@@ -782,6 +988,23 @@ pub fn shared_primary_action(
             let ray_dir = Quat::from_euler(EulerRot::YXZ, yaw.0, pitch.0, 0.0) * Vec3::NEG_Z;
             let filter = SpatialQueryFilter::from_excluded_entities([trigger.context]);
 
+            info!(
+                "[SHOOT] Fire! pos={:?} yaw={:.2} pitch={:.2} dir={:?} predicted={}",
+                eye_pos, yaw.0, pitch.0, ray_dir, is_predicted
+            );
+
+            // Log all players with colliders for debugging hit detection
+            if !is_predicted {
+                for (e, hp, pos) in health_query.iter() {
+                    info!(
+                        "[SHOOT] Potential target: {:?} pos={:?} hp={} dist={:.1}",
+                        e, pos.0, hp.0, eye_pos.distance(pos.0)
+                    );
+                }
+            }
+
+            let tracer_dist;
+
             if let Some(hit) = spatial_query.cast_ray(
                 eye_pos,
                 Dir3::new(ray_dir).unwrap_or(Dir3::NEG_Z),
@@ -789,13 +1012,43 @@ pub fn shared_primary_action(
                 true,
                 &filter,
             ) {
+                tracer_dist = hit.distance;
+                info!(
+                    "[SHOOT] Ray hit entity {:?} at distance {:.1}",
+                    hit.entity, hit.distance
+                );
                 if !is_predicted {
                     if let Ok((_entity, mut health, _pos)) = health_query.get_mut(hit.entity) {
                         health.0 -= SHOOT_DAMAGE;
-                        info!("Hit player for {} damage! Health: {}", SHOOT_DAMAGE, health.0);
+                        info!(
+                            "[SHOOT] Player hit! {} damage applied, health now: {}",
+                            SHOOT_DAMAGE, health.0
+                        );
+                    } else {
+                        info!("[SHOOT] Hit entity {:?} but it has no PlayerHealth", hit.entity);
                     }
                 }
+            } else {
+                tracer_dist = SHOOT_RANGE;
+                info!("[SHOOT] Miss — no ray hit within {} range", SHOOT_RANGE);
             }
+
+            // Look up muzzle offset from the Equippable component
+            let muzzle_local = equippable_query
+                .iter()
+                .find(|e| e.name == *name)
+                .and_then(|e| e.muzzle_offset)
+                .map(|o| Vec3::from_array(o))
+                .unwrap_or(Vec3::new(0.2, -0.1, -0.9));
+
+            let cam_rot = Quat::from_euler(EulerRot::YXZ, yaw.0, pitch.0, 0.0);
+            let muzzle_world = eye_pos + cam_rot * muzzle_local;
+            let hit_point = eye_pos + ray_dir * tracer_dist;
+
+            commands.trigger(ShotFired {
+                muzzle: muzzle_world,
+                hit_point,
+            });
         }
 
         // Tool equipped → mine nearby interactable
@@ -848,6 +1101,7 @@ pub fn shared_primary_action(
                             model_path: "ore_chunk.glb".to_string(),
                             interaction_distance: 2.0,
                             scale: 0.5,
+                            muzzle_offset: None,
                         },
                         Name::new("Ore Chunk"),
                         Replicate::to_clients(NetworkTarget::All),
@@ -888,7 +1142,7 @@ pub fn reset_stale_mining(
 
 /// Client-only: spawns/despawns the FPS view model when PlayerEquipped changes.
 pub fn update_view_model(
-    player_query: Query<(&PlayerEquipped, &Children), With<crate::player::LocalPlayer>>,
+    player_query: Query<(&PlayerEquipped, &Children), With<lightyear::prelude::Controlled>>,
     camera_query: Query<Entity, With<WorldModelCamera>>,
     view_model_query: Query<Entity, With<EquippedItem>>,
     equippable_query: Query<&Equippable>,
@@ -934,7 +1188,10 @@ pub fn update_view_model(
             SceneRoot(model_handle),
             Transform::from_xyz(0.2, -0.15, -0.4)
                 .with_scale(Vec3::splat(1.0))
-                .with_rotation(Quat::from_rotation_y(std::f32::consts::FRAC_PI_2)),
+                .with_rotation(
+                    Quat::from_rotation_y(std::f32::consts::FRAC_PI_2)
+                        * Quat::from_rotation_x(std::f32::consts::FRAC_PI_2),
+                ),
             RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
             EquippedItem {
                 name: tool_name.clone(),


### PR DESCRIPTION
## Summary
- Replace manual `LocalPlayer` with lightyear's `Controlled` pattern — no more manual guards in spawn observers
- Send mouse look through BEI `LookAction` for server-authoritative yaw/pitch — fixes remote player orientation, hit detection direction, and gun snap-back regression
- Add `sync_rotation_from_yaw` shared system encoding yaw+pitch into Rotation for remote player pitch visibility
- Add `gate_look_on_cursor` to fix cursor lock regression (mouse input gated on `CursorState.locked`)
- Add jab melee (Q), drop action (G), bullet tracers, health HUD, Ed25519 client identity
- Add rollback thresholds (0.01 delta) for Position/Rotation/CharacterVelocity to prevent float noise rollbacks
- Suppress BEI action type mismatch warnings on server

## Test plan
- [ ] Verify cursor lock/unlock works (click to grab, Escape to release)
- [ ] Verify remote players rotate and pitch correctly
- [ ] Verify shooting hits players and health bars update
- [ ] Verify jab melee works at close range
- [ ] Verify equip/drop cycle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)