### PR TITLE
Add CI/CD pipeline and server provisioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,168 @@
+name: Build & Release
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ============================================
+  # Build server binary (Linux x86_64)
+  # ============================================
+  build-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: server-linux-${{ hashFiles('Cargo.lock') }}
+          restore-keys: server-linux-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libudev-dev
+
+      - name: Build server
+        run: cargo build --release --bin server
+
+      - name: Upload server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-linux-x64
+          path: target/release/server
+
+  # ============================================
+  # Build client binaries (macOS arm64 + Windows x64)
+  # ============================================
+  build-client:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: ialy-macos-arm64
+            binary: client
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: ialy-windows-x64
+            binary: client.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: client-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: client-${{ matrix.os }}-
+
+      - name: Build client
+        run: cargo build --release --bin client --target ${{ matrix.target }}
+
+      - name: Package (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+          cp -r assets dist/
+          cd dist && zip -r ../${{ matrix.artifact }}.zip .
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" -Destination dist/
+          Copy-Item -Recurse assets dist/
+          Compress-Archive -Path dist/* -DestinationPath "${{ matrix.artifact }}.zip"
+
+      - name: Upload client package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.zip
+
+  # ============================================
+  # Deploy server (on push to master)
+  # ============================================
+  deploy-server:
+    needs: build-server
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    environment: production
+    steps:
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: server-linux-x64
+          path: .
+
+      - name: Deploy to game server
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Upload new binary
+          scp -i ~/.ssh/deploy_key server "root@${DEPLOY_HOST}:/opt/ialy/server.new"
+
+          # Atomic swap and restart
+          ssh -i ~/.ssh/deploy_key "root@${DEPLOY_HOST}" << 'REMOTE'
+            mv /opt/ialy/server.new /opt/ialy/server
+            chmod +x /opt/ialy/server
+            sudo systemctl restart ialy
+            sleep 2
+            systemctl is-active ialy
+          REMOTE
+
+  # ============================================
+  # Create GitHub Release (on version tag)
+  # ============================================
+  release:
+    needs: [build-client, build-server]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/ialy-macos-arm64/ialy-macos-arm64.zip
+            artifacts/ialy-windows-x64/ialy-windows-x64.zip
+            artifacts/server-linux-x64/server

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# IALY Game Server Provisioning Script
+# Run on a fresh Ubuntu/Debian VPS as root:
+#   ssh root@<server> 'bash -s' < provision.sh
+set -euo pipefail
+
+SERVER_USER="ialy"
+INSTALL_DIR="/opt/ialy"
+GAME_PORT=5000
+
+echo "=== IALY Server Provisioning ==="
+
+# 1. System updates
+echo "[1/7] Updating system packages..."
+apt-get update -qq && apt-get upgrade -y -qq
+
+# 2. Create service account (no login shell, no home dir needed)
+echo "[2/7] Creating service account: $SERVER_USER"
+if id "$SERVER_USER" &>/dev/null; then
+    echo "  User $SERVER_USER already exists, skipping"
+else
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$SERVER_USER"
+fi
+
+# 3. Create install directory
+echo "[3/7] Setting up $INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+chown "$SERVER_USER":"$SERVER_USER" "$INSTALL_DIR"
+
+# 4. Install systemd unit
+echo "[4/7] Installing systemd service: ialy.service"
+cat > /etc/systemd/system/ialy.service << 'UNIT'
+[Unit]
+Description=IALY Game Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ialy
+Group=ialy
+WorkingDirectory=/opt/ialy
+ExecStart=/opt/ialy/server
+Restart=always
+RestartSec=5
+
+# Resource limits
+LimitNOFILE=65535
+MemoryMax=4G
+Nice=-5
+
+# Security hardening
+ProtectSystem=strict
+ReadWritePaths=/opt/ialy
+ProtectHome=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ialy
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable ialy.service
+
+# 5. Firewall (UFW)
+echo "[5/7] Configuring firewall..."
+apt-get install -y -qq ufw
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp comment "SSH"
+ufw allow ${GAME_PORT}/udp comment "IALY game server"
+ufw --force enable
+ufw status verbose
+
+# 6. Harden SSH — disable password auth
+echo "[6/7] Hardening SSH (key-only auth)..."
+sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+sed -i 's/^#\?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+systemctl restart sshd
+
+# 7. Allow ialy user to restart its own service (for CI deploy)
+echo "[7/7] Setting up deploy permissions..."
+cat > /etc/sudoers.d/ialy-deploy << 'SUDOERS'
+# Allow root to restart ialy service (used by CI deploy via SSH as root)
+# No additional sudoers needed — CI SSHes in as root
+SUDOERS
+chmod 440 /etc/sudoers.d/ialy-deploy
+
+echo ""
+echo "=== Provisioning complete ==="
+echo ""
+echo "Server directory:  $INSTALL_DIR"
+echo "Service name:      ialy.service"
+echo "Game port:         ${GAME_PORT}/udp"
+echo "Service user:      $SERVER_USER"
+echo ""
+echo "Next steps:"
+echo "  1. Upload the server binary to $INSTALL_DIR/server"
+echo "  2. chmod +x $INSTALL_DIR/server"
+echo "  3. systemctl start ialy"
+echo "  4. journalctl -u ialy -f   (watch logs)"
+echo ""
+echo "To deploy updates:"
+echo "  scp server root@<this-host>:$INSTALL_DIR/server.new"
+echo "  ssh root@<this-host> 'mv $INSTALL_DIR/server.new $INSTALL_DIR/server && chmod +x $INSTALL_DIR/server && systemctl restart ialy'"


### PR DESCRIPTION
## Summary
- GitHub Actions workflow for building server (Linux), client (macOS + Windows), auto-deploying to game server, and creating GitHub Releases on tags
- Server provisioning script for fresh VPS setup (systemd, UFW, SSH hardening)

## Details

**CI Pipeline** (`.github/workflows/build.yml`):
- `build-server`: Compiles Linux x86_64 server binary
- `build-client`: Matrix build — macOS arm64 + Windows x64, packages binary + assets into ZIP
- `deploy-server`: On push to master — SCPs binary to game server, restarts systemd service
- `release`: On version tag (v*) — creates GitHub Release with platform ZIPs

**Provisioning** (`deploy/provision.sh`):
- Creates `ialy` service account and `/opt/ialy/` directory
- Installs `ialy.service` systemd unit (auto-restart, resource limits, security hardening)
- Configures UFW firewall (22/tcp SSH + 5000/udp game only)
- Disables SSH password auth (key-only)

**Required secrets**: `DEPLOY_HOST`, `DEPLOY_SSH_KEY` (already configured)

## Test plan
- [ ] Merge to master triggers build-server + build-client jobs
- [ ] Server binary deploys to SLC game server via SCP
- [ ] `systemctl status ialy` shows active after deploy
- [ ] Tag push (e.g. `v0.3.0`) creates GitHub Release with macOS + Windows ZIPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)