### PR TITLE
Fix headless server GPU panic

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -18,7 +18,6 @@ fn main() {
             .build()
             .disable::<bevy::winit::WinitPlugin>()
             .disable::<bevy::render::RenderPlugin>()
-            .disable::<bevy::render::pipelined_rendering::PipelinedRenderingPlugin>()
             .disable::<bevy::core_pipeline::CorePipelinePlugin>()
             .disable::<bevy::pbr::PbrPlugin>()
             .disable::<bevy::gltf::GltfPlugin>()

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -21,6 +21,7 @@ fn main() {
             .disable::<bevy::core_pipeline::CorePipelinePlugin>()
             .disable::<bevy::pbr::PbrPlugin>()
             .disable::<bevy::gltf::GltfPlugin>()
+            .disable::<bevy::sprite::SpritePlugin>()
             .disable::<bevy::ui::UiPlugin>()
             .disable::<bevy::text::TextPlugin>()
             .set(bevy::window::WindowPlugin {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -24,7 +24,6 @@ fn main() {
             .disable::<bevy::gltf::GltfPlugin>()
             .disable::<bevy::ui::UiPlugin>()
             .disable::<bevy::text::TextPlugin>()
-            .disable::<bevy::picking::PickingPlugin>()
             .set(bevy::window::WindowPlugin {
                 primary_window: None,
                 primary_cursor_options: None,

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -17,6 +17,14 @@ fn main() {
         DefaultPlugins
             .build()
             .disable::<bevy::winit::WinitPlugin>()
+            .disable::<bevy::render::RenderPlugin>()
+            .disable::<bevy::render::pipelined_rendering::PipelinedRenderingPlugin>()
+            .disable::<bevy::core_pipeline::CorePipelinePlugin>()
+            .disable::<bevy::pbr::PbrPlugin>()
+            .disable::<bevy::gltf::GltfPlugin>()
+            .disable::<bevy::ui::UiPlugin>()
+            .disable::<bevy::text::TextPlugin>()
+            .disable::<bevy::picking::PickingPlugin>()
             .set(bevy::window::WindowPlugin {
                 primary_window: None,
                 primary_cursor_options: None,


### PR DESCRIPTION
## Summary
- Disable render-dependent plugins (RenderPlugin, PipelinedRenderingPlugin, CorePipelinePlugin, PbrPlugin, GltfPlugin, UiPlugin, TextPlugin, PickingPlugin) from the headless server binary
- Server was panicking on GPU-less VPS with `Unable to find a GPU!` because DefaultPlugins initializes the render pipeline
- Headless server only needs physics (Avian3d) and networking (Lightyear) — no rendering required

## Test plan
- [ ] Build server binary on VPS and verify it starts without GPU panic
- [ ] Verify client can still connect and play normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)