### PR TITLE
Replace kinematic controller with avian dynamic rigid body

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1138,9 +1138,11 @@ fn on_predicted_spawn(
         .map(|p| Transform::from_translation(p.0))
         .unwrap_or(Transform::from_translation(PLAYER_SPAWN_POS));
 
-    // All predicted entities get physics + basic components
+    // All predicted entities get dynamic physics — our character controller
+    // now lives entirely in avian's integrator, so predicted clients must
+    // simulate the same forces/impulses the server does.
     commands.entity(entity).insert((
-        player_physics_bundle(),
+        player_physics_bundle_dynamic(),
         Player { id: player_id.0 },
         spawn_transform,
         Visibility::default(),
@@ -1227,8 +1229,13 @@ fn on_interpolated_spawn(
 
     info!("[SPAWN] Remote interpolated player spawned: {:?} (id={})", entity, player_id.0);
 
+    // Interpolated (remote) players get a Kinematic body so avian's gravity
+    // doesn't tug them down between replication snapshots — lightyear drives
+    // their Position/Rotation from interpolated history. The collider is
+    // still present so local ray-casts (tracers, prediction-only visuals)
+    // can hit them.
     commands.entity(entity).insert((
-        player_physics_bundle(),
+        player_physics_bundle_kinematic(),
         Player { id: player_id.0 },
         Mesh3d(meshes.add(Capsule3d::default())),
         MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -10,7 +10,7 @@ use lightyear_avian3d::prelude::{LagCompensationHistory, LagCompensationPlugin, 
 use avian3d::prelude::SpatialQueryFilter;
 
 use multiplayer::auth::{self, VerifiedWallets};
-use multiplayer::player::{player_physics_bundle, player_replicated_bundle, select_spawn_point};
+use multiplayer::player::{player_physics_bundle_dynamic, player_replicated_bundle, select_spawn_point};
 use multiplayer::protocol::{KillFeedEntry, LastDamagedBy, PlayerActions, PlayerId, PlayerDead, PlayerEquipped, PlayerHealth, PlayerDisplayId, PlayerInventory, PlayerYaw, PlayerPitch, WalletAuthMessage};
 use multiplayer::solana::{self, RespawnAuth, RespawnConfig, WalletAddress};
 use multiplayer::world::{spawn_server_interactive_objects, spawn_world_physics, Equippable};
@@ -188,7 +188,7 @@ fn handle_connected(
 
     commands.spawn((
         player_replicated_bundle(client_id_bits),
-        player_physics_bundle(),
+        player_physics_bundle_dynamic(),
         PlayerDisplayId(display_id),
         // WalletAddress starts empty — populated after auth verification
         WalletAddress::default(),
@@ -444,7 +444,16 @@ fn check_player_death(
 ///   ANIMA_RESPAWN token balance or SOL balance via Solana RPC.
 fn process_respawns(
     mut pending: ResMut<PendingRespawns>,
-    mut query: Query<(&mut PlayerHealth, &mut Position, &mut avian3d::prelude::Rotation, &PlayerId, &mut PlayerEquipped, &mut PlayerInventory), With<PlayerDead>>,
+    mut query: Query<(
+        &mut PlayerHealth,
+        &mut Position,
+        &mut avian3d::prelude::Rotation,
+        &mut avian3d::prelude::LinearVelocity,
+        &mut avian3d::prelude::AngularVelocity,
+        &PlayerId,
+        &mut PlayerEquipped,
+        &mut PlayerInventory,
+    ), With<PlayerDead>>,
     living_query: Query<&Position, (With<PlayerId>, Without<PlayerDead>)>,
     mut commands: Commands,
     time: Res<Time>,
@@ -457,7 +466,7 @@ fn process_respawns(
         if now >= pending.timers[i].1 {
             let (entity, _) = pending.timers.remove(i);
 
-            let Ok((mut health, mut position, mut rotation, player_id, mut equipped, mut inventory)) = query.get_mut(entity) else {
+            let Ok((mut health, mut position, mut rotation, mut lin_vel, mut ang_vel, player_id, mut equipped, mut inventory)) = query.get_mut(entity) else {
                 continue;
             };
 
@@ -473,6 +482,11 @@ fn process_respawns(
                     health.0 = 100;
                     position.0 = spawn_pos;
                     rotation.0 = Quat::IDENTITY;
+                    // Reset avian velocities — otherwise kill-plane death leaves
+                    // residual -Y velocity that would slingshot the respawned
+                    // player back downwards.
+                    lin_vel.0 = Vec3::ZERO;
+                    ang_vel.0 = Vec3::ZERO;
                     // Ensure inventory is clean on respawn (should already be empty from death drop)
                     equipped.0 = None;
                     inventory.items.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,20 @@ pub struct SharedPlugin;
 
 impl Plugin for SharedPlugin {
     fn build(&self, app: &mut App) {
-        // Protocol: components + BEI input registration
+        // Protocol: components + leafwing input registration
         app.add_plugins(protocol::ProtocolPlugin);
 
-        // Avian3d physics with lightyear integration
-        // PositionButInterpolateTransform: lightyear handles Position→Transform sync
-        // with smooth correction for predicted entities and interpolation for remote entities.
+        // Avian3d physics with lightyear integration.
+        //
+        // `Position` mode: lightyear replicates & rolls back `Position`/`Rotation`
+        // directly (matching the `lightyear/examples/avian_3d_character` pattern).
+        // This is the right choice for a dynamic rigid body controller because
+        // avian's integrator is the authority on Position, and lightyear's
+        // prediction replays the same forces/impulses through the integrator to
+        // get a deterministic result — no bespoke Position writebacks to clash
+        // with lightyear.
         app.add_plugins(LightyearAvianPlugin {
-            replication_mode: AvianReplicationMode::PositionButInterpolateTransform,
+            replication_mode: AvianReplicationMode::Position,
             ..default()
         });
         app.add_plugins(
@@ -34,32 +40,27 @@ impl Plugin for SharedPlugin {
                 .build()
                 .disable::<PhysicsTransformPlugin>()
                 .disable::<PhysicsInterpolationPlugin>()
+                // Sleeping can stash state that doesn't survive rollback cleanly.
                 .disable::<IslandPlugin>()
                 .disable::<IslandSleepingPlugin>(),
         );
 
-        // Disable gravity for kinematic players (we handle gravity ourselves).
-        // Other dynamic entities (like ore chunks) still use default gravity.
+        // Real gravity — avian integrates it into dynamic bodies each tick.
+        // The old code zeroed gravity because our custom kinematic controller
+        // applied its own; now avian owns the whole vertical axis.
         app.insert_resource(Gravity(Vec3::new(0.0, -9.81, 0.0)));
 
-        // Note: FrameInterpolationPlugin is NOT needed — PositionButInterpolateTransform
-        // mode handles Position→Transform and Rotation→Transform sync with smooth correction.
-
-        // Shared FixedUpdate systems. These replace the old BEI `On<Fire<...>>`
-        // observers — leafwing's ActionState is snapshot/restored cleanly during
-        // lightyear rollback, so movement/look/jump/interact/etc can be replayed
-        // without the rubber-banding that event-based observers caused.
-        //
-        // Movement reads the world-space Move axis (rotated on the client before
-        // BufferClientInputs). With zero input the movement system zeros XZ vel
-        // directly — no separate clear_xz_velocity step required.
+        // Shared FixedUpdate systems. `handle_character_actions` replaces our
+        // old custom kinematic controller: it walks every player, reads the
+        // leafwing ActionState, and applies forces/impulses via avian's
+        // `Forces` query data. The avian `PhysicsSchedule` (in FixedPostUpdate)
+        // then integrates those forces into Position — the same integration
+        // runs again on replay, which is what keeps us rollback-deterministic.
         app.add_systems(
             FixedUpdate,
             (
                 player::shared_look_system,
-                player::shared_movement_system,
-                player::shared_jump_system,
-                player::character_controller,
+                player::handle_character_actions,
                 player::sync_rotation_from_yaw,
                 world::shared_door_interact_system,
                 world::shared_equip_interact_system,

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,6 +1,7 @@
 use std::f32::consts::FRAC_PI_2;
 
 use avian3d::prelude::*;
+use avian3d::prelude::forces::ForcesItem;
 use bevy::{
     prelude::*,
     window::{CursorGrabMode, CursorOptions, PrimaryWindow},
@@ -11,15 +12,22 @@ use avian3d::prelude::Rotation;
 use lightyear::prelude::{Controlled, Interpolated};
 
 use crate::protocol::{
-    CharacterVelocity, PlayerActions, PlayerDead, PlayerEquipped, PlayerHealth, PlayerId,
-    PlayerPitch, PlayerYaw,
+    PlayerActions, PlayerDead, PlayerEquipped, PlayerHealth, PlayerId, PlayerPitch, PlayerYaw,
 };
 
-pub const PLAYER_MOVE_SPEED: f32 = 7.0;
-pub const JUMP_SPEED: f32 = 10.0;
-pub const GRAVITY: f32 = 32.0;
-pub const SKIN_WIDTH: f32 = 0.02;
-pub const STEP_HEIGHT: f32 = 0.1;
+// --- Movement feel tunables ---
+//
+// With avian's dynamic rigid body pattern, motion is produced by applying
+// forces (horizontal) and impulses (vertical). These constants tune the feel.
+/// Horizontal ground speed cap (m/s).
+pub const MAX_SPEED: f32 = 7.0;
+/// Max horizontal acceleration (m/s²). Controls how snappy start/stop/strafe feels.
+pub const MAX_ACCELERATION: f32 = 50.0;
+/// Vertical impulse applied on jump (m/s ⋅ kg — effective jump height scales
+/// with inverse mass). With avian's default mass and Gravity(-9.81), ~5.4 lifts
+/// us ~1.5 m.
+pub const JUMP_IMPULSE: f32 = 5.4;
+
 pub const VIEW_MODEL_RENDER_LAYER: usize = 1;
 pub const PLAYER_SPAWN_POS: Vec3 = Vec3::new(0.0, 1.5, 5.0);
 
@@ -57,12 +65,10 @@ pub fn select_spawn_point(living_positions: &[Vec3]) -> Vec3 {
         .unwrap_or(PLAYER_SPAWN_POS)
 }
 
-/// Capsule dimensions (must match Collider in physics bundle)
-const CAPSULE_RADIUS: f32 = 0.5;
-const CAPSULE_HEIGHT: f32 = 1.0;
-
-/// Surface normal must have Y > this to count as walkable ground (~45° max slope)
-const MIN_GROUND_NORMAL_Y: f32 = 0.7;
+/// Capsule dimensions (must match Collider in physics bundle).
+/// These are the half-extents avian uses: total height ≈ 2*radius + height = ~2m.
+pub const CAPSULE_RADIUS: f32 = 0.5;
+pub const CAPSULE_HEIGHT: f32 = 1.0;
 
 // --- Shared Components (used by both server + client) ---
 
@@ -98,13 +104,48 @@ impl Default for CursorState {
 // These ensure server and client have identical physics/gameplay components.
 // Define once here, use in both server.rs and client.rs.
 
-/// Physics components for a player entity. Kinematic — we control Position directly
-/// via the character controller. Avian detects collisions but doesn't move us.
-pub fn player_physics_bundle() -> impl Bundle {
+/// Physics for locally-simulated player entities — the server's authoritative
+/// player and the client's predicted (controlled) player.
+///
+/// Dynamic rigid body driven by avian's integrator. Forces applied via
+/// `ForcesItem` give deterministic motion under lightyear's rollback — unlike
+/// our old kinematic character controller, whose SpatialQuery-driven writes
+/// produced different results when replayed because it sampled the *current*
+/// collider positions rather than the replay-tick positions.
+///
+/// Rotations are locked on all axes so the capsule never tips over; our
+/// `sync_rotation_from_yaw` system writes `Rotation` each tick based on the
+/// replicated yaw/pitch so the facing direction is still deterministic.
+/// Zero friction with Min combine prevents sticky contacts that would cause
+/// rubber-banding on sloped geometry.
+pub fn player_physics_bundle_dynamic() -> impl Bundle {
+    (
+        Collider::capsule(CAPSULE_RADIUS, CAPSULE_HEIGHT),
+        RigidBody::Dynamic,
+        LockedAxes::default()
+            .lock_rotation_x()
+            .lock_rotation_y()
+            .lock_rotation_z(),
+        Friction::new(0.0).with_combine_rule(CoefficientCombine::Min),
+    )
+}
+
+/// Physics for the client's view of remote, interpolated players. Kinematic so
+/// avian doesn't try to simulate gravity/forces locally — lightyear drives
+/// Position/Rotation from interpolated snapshots instead. Collider is still
+/// present so local ray-casts (tracers, prediction-only visuals) hit them.
+pub fn player_physics_bundle_kinematic() -> impl Bundle {
     (
         Collider::capsule(CAPSULE_RADIUS, CAPSULE_HEIGHT),
         RigidBody::Kinematic,
     )
+}
+
+/// Back-compat alias used by a couple of sites that don't care which variant
+/// — just need a collider + rigid body. Defaults to the kinematic flavour so
+/// passive use doesn't accidentally spawn a dynamic body that falls forever.
+pub fn player_physics_bundle() -> impl Bundle {
+    player_physics_bundle_kinematic()
 }
 
 /// Replicated gameplay state for a player entity.
@@ -113,6 +154,11 @@ pub fn player_physics_bundle() -> impl Bundle {
 /// `ActionState<PlayerActions>` is the leafwing equivalent of the old BEI
 /// `PlayerContext` marker — it's the replicated input component queried each
 /// FixedUpdate by shared movement/shoot/etc systems on both ends.
+///
+/// Note: `LinearVelocity` / `AngularVelocity` / `ComputedMass` are added
+/// automatically by avian as required components of `RigidBody`, so we don't
+/// include them here. They are still registered for replication in
+/// `ProtocolPlugin` so predicted clients see the server's velocity state.
 pub fn player_replicated_bundle(client_id: u64) -> impl Bundle {
     (
         ActionState::<PlayerActions>::default(),
@@ -124,83 +170,103 @@ pub fn player_replicated_bundle(client_id: u64) -> impl Bundle {
         PlayerHealth::default(),
         crate::protocol::LastDamagedBy::default(),
         crate::protocol::LastShot::default(),
-        CharacterVelocity::default(),
         Position(PLAYER_SPAWN_POS),
         Rotation::default(),
     )
 }
 
-// --- Shared Movement (FixedUpdate, runs on both client + server) ---
+// --- Shared Character Action Application (FixedUpdate, runs on both client + server) ---
 
-/// Reads the Move dual-axis from each player's ActionState and applies it to their
-/// CharacterVelocity. Input is already world-space (pre-rotated by camera yaw on
-/// the client before lightyear buffers the ActionState for replication).
+/// Apply the character action for a single entity. Mirrors the
+/// `lightyear/examples/avian_3d_character` pattern:
 ///
-/// Runs every FixedUpdate on both client (prediction) and server (authority).
-/// Leafwing's ActionState is snapshot/restored cleanly across rollback — so this
-/// system can be called during replay without the rubber-banding that plagued BEI.
-pub fn shared_movement_system(
-    mut query: Query<
-        (&ActionState<PlayerActions>, &mut CharacterVelocity, Has<Interpolated>, Has<PlayerDead>),
-        With<PlayerId>,
-    >,
+/// - Jump: on `just_pressed(Jump)`, raycast down from the capsule bottom; if
+///   we're grounded, apply an instantaneous linear impulse upwards.
+/// - Move: compute a target ground velocity from the pre-rotated Move axis,
+///   then apply the force required to reach that target this tick, bounded by
+///   `MAX_ACCELERATION`.
+///
+/// This is deterministic under rollback because forces are applied to an
+/// avian rigid body — avian's integrator consumes the same forces each replay
+/// and produces the same position delta. The old kinematic controller's
+/// SpatialQuery-driven writes weren't rollback-safe because SpatialQuery reads
+/// the *current* collider positions, not the replay-tick positions.
+pub fn apply_character_action(
+    entity: Entity,
+    mass: &ComputedMass,
+    time: &Res<Time>,
+    spatial_query: &SpatialQuery,
+    action_state: &ActionState<PlayerActions>,
+    mut forces: ForcesItem,
 ) {
-    for (action, mut vel, is_interpolated, is_dead) in query.iter_mut() {
-        if is_interpolated || is_dead {
-            continue;
+    // How much horizontal velocity can change in a single tick.
+    let max_velocity_delta_per_tick = MAX_ACCELERATION * time.delta_secs();
+
+    // --- Jump ---
+    if action_state.just_pressed(&PlayerActions::Jump) {
+        // Raycast down from the bottom of the capsule; only jump if we hit
+        // something right below us.
+        let foot = forces.position().0
+            + Vec3::new(0.0, -CAPSULE_HEIGHT / 2.0 - CAPSULE_RADIUS, 0.0);
+        let grounded = spatial_query
+            .cast_ray(
+                foot,
+                Dir3::NEG_Y,
+                0.01,
+                true,
+                &SpatialQueryFilter::from_excluded_entities([entity]),
+            )
+            .is_some();
+        if grounded {
+            forces.apply_linear_impulse(Vec3::new(0.0, JUMP_IMPULSE, 0.0));
         }
-
-        let input = action.axis_pair(&PlayerActions::Move);
-
-        if input == Vec2::ZERO {
-            vel.0.x = 0.0;
-            vel.0.z = 0.0;
-            continue;
-        }
-
-        let move_dir = input.normalize_or_zero();
-        vel.0.x = move_dir.x * PLAYER_MOVE_SPEED;
-        vel.0.z = move_dir.y * PLAYER_MOVE_SPEED;
     }
+
+    // --- Move ---
+    // The Move axis is already in world space (the client pre-rotates by
+    // camera yaw before lightyear buffers ActionState). Convention matches the
+    // old pre_rotate: +x = world X (right), +y = world -Z (forward) — pressing
+    // W at yaw=0 gives axis (0, -1) which maps to world (0, 0, -1).
+    let raw = action_state
+        .axis_pair(&PlayerActions::Move)
+        .clamp_length_max(1.0);
+    let move_dir = Vec3::new(raw.x, 0.0, raw.y);
+
+    let linear_velocity = forces.linear_velocity();
+    let ground_linear_velocity = Vec3::new(linear_velocity.x, 0.0, linear_velocity.z);
+
+    let desired_ground_linear_velocity = move_dir * MAX_SPEED;
+
+    let new_ground_linear_velocity = ground_linear_velocity
+        .move_towards(desired_ground_linear_velocity, max_velocity_delta_per_tick);
+
+    // Acceleration needed to hit the target this tick. `move_towards` already
+    // bounds the delta by `max_velocity_delta_per_tick`, so the magnitude is
+    // guaranteed ≤ MAX_ACCELERATION.
+    let required_acceleration =
+        (new_ground_linear_velocity - ground_linear_velocity) / time.delta_secs();
+
+    forces.apply_force(required_acceleration * mass.value());
 }
 
-/// Jump: set upward velocity if grounded. Shared between client + server.
-/// Triggered by just_pressed(Jump) so a single keypress fires one jump even
-/// though the key may be held across multiple ticks.
-pub fn shared_jump_system(
+/// FixedUpdate system: walks every player with an ActionState + Forces and
+/// delegates to `apply_character_action`. Runs on both the client (for the
+/// locally-predicted controlled entity) and the server (for all players).
+///
+/// Skips interpolated / dead players.
+pub fn handle_character_actions(
+    time: Res<Time>,
+    spatial_query: SpatialQuery,
     mut query: Query<
-        (Entity, &ActionState<PlayerActions>, &mut CharacterVelocity, &Position, Has<Interpolated>, Has<PlayerDead>),
+        (Entity, &ComputedMass, &ActionState<PlayerActions>, Forces, Has<Interpolated>, Has<PlayerDead>),
         With<PlayerId>,
     >,
-    spatial_query: SpatialQuery,
 ) {
-    for (entity, action, mut vel, position, is_interpolated, is_dead) in query.iter_mut() {
+    for (entity, mass, action_state, forces, is_interpolated, is_dead) in query.iter_mut() {
         if is_interpolated || is_dead {
             continue;
         }
-        if !action.just_pressed(&PlayerActions::Jump) {
-            continue;
-        }
-        if vel.0.y > 0.5 {
-            continue;
-        }
-
-        let capsule = Collider::capsule(CAPSULE_RADIUS, CAPSULE_HEIGHT);
-        let config = ShapeCastConfig {
-            max_distance: 0.15,
-            target_distance: SKIN_WIDTH,
-            compute_contact_on_penetration: true,
-            ignore_origin_penetration: true,
-        };
-        let filter = SpatialQueryFilter::from_excluded_entities([entity]);
-
-        if let Some(hit) = spatial_query.cast_shape(
-            &capsule, position.0, Quat::IDENTITY, Dir3::NEG_Y, &config, &filter,
-        ) {
-            if hit.normal1.y > MIN_GROUND_NORMAL_Y {
-                vel.0.y = JUMP_SPEED;
-            }
-        }
+        apply_character_action(entity, mass, &time, &spatial_query, action_state, forces);
     }
 }
 
@@ -230,177 +296,9 @@ pub fn shared_look_system(
     }
 }
 
-// --- Kinematic Character Controller ---
-
-/// Kinematic character controller. Runs every fixed tick on both client + server.
-/// Handles gravity, ground detection via shape cast, and move-and-slide collision.
-///
-/// Uses ParamSet because SpatialQuery reads Position internally (for all colliders),
-/// and we also need to write Position for players. We collect→compute→writeback.
-/// Kinematic character controller. Runs every fixed tick on both client + server.
-/// Handles gravity, ground detection via shape cast, and move-and-slide collision.
-///
-/// All Position-accessing params must live inside the ParamSet because SpatialQuery
-/// reads Position for all colliders, and we need to write Position for players.
-/// Flow: collect (p0) → shape cast (p1) → write back (p2).
-pub fn character_controller(
-    mut params: ParamSet<(
-        Query<(Entity, &Position, &CharacterVelocity), (With<PlayerId>, With<Collider>, Without<Interpolated>)>,
-        SpatialQuery,
-        Query<(&mut Position, &mut CharacterVelocity), (With<PlayerId>, With<Collider>, Without<Interpolated>)>,
-    )>,
-    time: Res<Time>,
-) {
-    let dt = time.delta_secs();
-    let capsule = Collider::capsule(CAPSULE_RADIUS, CAPSULE_HEIGHT);
-    // Shorter capsule for horizontal casts — bottom raised by STEP_HEIGHT
-    // to prevent scraping the ground and gives basic stair-stepping
-    let h_capsule = Collider::capsule(CAPSULE_RADIUS, (CAPSULE_HEIGHT - STEP_HEIGHT * 2.0).max(0.0));
-
-    // 1. Collect current state
-    let players: Vec<(Entity, Vec3, Vec3)> = params
-        .p0()
-        .iter()
-        .map(|(e, p, v)| (e, p.0, v.0))
-        .collect();
-
-    // 2. Compute new positions using SpatialQuery
-    let spatial = params.p1();
-    let mut results: Vec<(Entity, Vec3, Vec3)> = Vec::with_capacity(players.len());
-
-    for (entity, mut pos, mut vel) in players {
-        let filter = SpatialQueryFilter::from_excluded_entities([entity]);
-
-        // Apply gravity
-        vel.y -= GRAVITY * dt;
-
-        // --- Horizontal move-and-slide ---
-        let h_vel = Vec3::new(vel.x, 0.0, vel.z);
-        if h_vel.length_squared() > 0.0001 {
-            let h_delta = h_vel * dt;
-            pos += move_and_slide(&spatial, &h_capsule, pos, h_delta, &filter);
-        }
-
-        // --- Vertical movement + ground detection ---
-        if vel.y <= 0.0 {
-            let fall_dist = vel.y.abs() * dt + 0.1;
-            let config = ShapeCastConfig {
-                max_distance: fall_dist,
-                target_distance: SKIN_WIDTH,
-                compute_contact_on_penetration: true,
-                ignore_origin_penetration: true,
-            };
-
-            match spatial.cast_shape(
-                &capsule, pos, Quat::IDENTITY, Dir3::NEG_Y, &config, &filter,
-            ) {
-                Some(hit) if hit.normal1.y > MIN_GROUND_NORMAL_Y => {
-                    // Hit walkable ground — snap and zero vertical velocity
-                    if hit.distance > 0.0 {
-                        pos.y -= hit.distance;
-                    }
-                    vel.y = 0.0;
-                }
-                _ => {
-                    // Airborne or hit a wall/steep slope — keep falling
-                    pos.y += vel.y * dt;
-                }
-            }
-        } else {
-            // Moving upward (jumping) — cast for ceiling
-            let up_dist = vel.y * dt;
-            let config = ShapeCastConfig {
-                max_distance: up_dist,
-                target_distance: SKIN_WIDTH,
-                compute_contact_on_penetration: true,
-                ignore_origin_penetration: true,
-            };
-
-            match spatial.cast_shape(
-                &capsule, pos, Quat::IDENTITY, Dir3::Y, &config, &filter,
-            ) {
-                Some(hit) => {
-                    if hit.distance > 0.0 {
-                        pos.y += hit.distance;
-                    }
-                    vel.y = 0.0;
-                }
-                None => {
-                    pos.y += up_dist;
-                }
-            }
-        }
-
-        results.push((entity, pos, vel));
-    }
-
-    // 3. Write back results
-    drop(spatial);
-    let mut writeback = params.p2();
-    for (entity, new_pos, new_vel) in results {
-        if let Ok((mut pos, mut vel)) = writeback.get_mut(entity) {
-            pos.0 = new_pos;
-            vel.0 = new_vel;
-        }
-    }
-}
-
-/// Cast the player capsule in `delta` direction. On collision, slide along the surface.
-/// Returns the actual displacement to apply. Max 2 iterations (move + slide).
-fn move_and_slide(
-    spatial_query: &SpatialQuery,
-    shape: &Collider,
-    mut origin: Vec3,
-    mut remaining: Vec3,
-    filter: &SpatialQueryFilter,
-) -> Vec3 {
-    let mut total = Vec3::ZERO;
-
-    for _ in 0..2 {
-        let dist = remaining.length();
-        if dist < 0.0001 {
-            break;
-        }
-
-        let Ok(dir) = Dir3::new(remaining / dist) else {
-            break;
-        };
-
-        let config = ShapeCastConfig {
-            max_distance: dist,
-            target_distance: SKIN_WIDTH,
-            compute_contact_on_penetration: true,
-            ignore_origin_penetration: true,
-        };
-
-        match spatial_query.cast_shape(shape, origin, Quat::IDENTITY, dir, &config, filter) {
-            Some(hit) => {
-                // Move up to the surface (distance already accounts for skin via target_distance)
-                let step = dir.as_vec3() * hit.distance;
-                total += step;
-                origin += step;
-
-                // Project remaining movement onto the surface to slide
-                let leftover = dist - hit.distance;
-                if leftover < 0.001 {
-                    break;
-                }
-                let slide_vec = remaining.normalize() * leftover;
-                remaining = slide_vec - hit.normal1 * slide_vec.dot(hit.normal1);
-            }
-            None => {
-                total += remaining;
-                break;
-            }
-        }
-    }
-
-    total
-}
-
 /// Diagnostic: log player position/velocity every 2 seconds.
 pub fn log_player_state(
-    query: Query<(Entity, &Position, &CharacterVelocity), (With<PlayerId>, With<Collider>)>,
+    query: Query<(Entity, &Position, &LinearVelocity), (With<PlayerId>, With<Collider>)>,
     time: Res<Time>,
     mut timer: Local<f32>,
 ) {
@@ -422,6 +320,10 @@ pub fn log_player_state(
 /// Shared system: syncs PlayerYaw + PlayerPitch → Rotation so lightyear replicates
 /// both facing direction and pitch tilt. Runs in FixedUpdate on both client and server.
 /// Remote players display correct pitch tilt via the replicated Rotation.
+///
+/// Compatible with the dynamic rigid body: `LockedAxes` prevents the avian
+/// integrator from rotating the capsule, so our direct Rotation writes persist
+/// through the physics step.
 pub fn sync_rotation_from_yaw(
     mut query: Query<(&PlayerYaw, &PlayerPitch, &mut Rotation), (With<PlayerId>, Without<Interpolated>)>,
 ) {
@@ -452,7 +354,7 @@ pub fn pre_rotate_move_input(
         return;
     }
     let yaw = player_yaw.0;
-    // WASD yields: x = strafe (+right), y = forward (+up on screen = +W).
+    // WASD yields: x = strafe (+right), y = forward (+W).
     // World forward at yaw=0 is -Z, world right at yaw=0 is +X.
     let forward = Vec2::new(-yaw.sin(), -yaw.cos());
     let right = Vec2::new(yaw.cos(), -yaw.sin());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -54,11 +54,6 @@ impl_vector_space_f32!(PlayerPitch);
 #[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
 pub struct PlayerPitch(pub f32);
 
-/// Player velocity managed by our kinematic character controller.
-/// Not Avian's LinearVelocity — we own this completely.
-#[derive(Component, Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
-pub struct CharacterVelocity(pub Vec3);
-
 // --- Input Actions (leafwing) ---
 //
 // Single enum replaces the per-struct BEI actions. `ActionState<PlayerActions>`
@@ -238,10 +233,16 @@ impl Plugin for ProtocolPlugin {
             .add_linear_interpolation()
             .enable_correction();
 
-        // Our kinematic velocity (replaces Avian's LinearVelocity for players)
-        app.register_component::<CharacterVelocity>()
+        // Avian's authoritative dynamic-body velocities. Replicated + predicted
+        // so the client can integrate locally between server snapshots and the
+        // server's motion stays authoritative. Threshold absorbs ~4 ticks of
+        // per-tick gravity delta.
+        app.register_component::<LinearVelocity>()
             .add_prediction()
-            .add_should_rollback(velocity_should_rollback);
+            .add_should_rollback(linear_velocity_should_rollback);
+        app.register_component::<AngularVelocity>()
+            .add_prediction()
+            .add_should_rollback(angular_velocity_should_rollback);
 
         // World object components — replicated, server-authoritative (no prediction)
         app.register_component::<crate::world::DoorState>();
@@ -282,8 +283,14 @@ fn rotation_should_rollback(this: &Rotation, that: &Rotation) -> bool {
     this.angle_between(*that) >= 0.05 // ~3°
 }
 
-// Per-tick velocity delta from gravity is 0.5 m/s; threshold needs to be much larger
-// to absorb input timing jitter without thrashing.
-fn velocity_should_rollback(this: &CharacterVelocity, that: &CharacterVelocity) -> bool {
-    (this.0 - that.0).length() >= 2.0 // 2 m/s — 4x the per-tick gravity delta
+// Per-tick velocity delta from gravity is ~0.15 m/s; threshold needs to be
+// much larger than that to absorb input timing jitter without thrashing.
+fn linear_velocity_should_rollback(this: &LinearVelocity, that: &LinearVelocity) -> bool {
+    (this.0 - that.0).length() >= 2.0 // 2 m/s
+}
+
+// Locked rotation means angular velocity is effectively always zero on players,
+// so almost any drift is noise; keep the gate permissive.
+fn angular_velocity_should_rollback(this: &AngularVelocity, that: &AngularVelocity) -> bool {
+    (this.0 - that.0).length() >= 1.0
 }


### PR DESCRIPTION
## Summary

- Delete our custom kinematic `character_controller` (+ `move_and_slide`) and let avian integrate motion from forces/impulses instead — matching the `lightyear/examples/avian_3d_character` pattern.
- Replace `CharacterVelocity` with avian's `LinearVelocity` (registered for prediction + rollback).
- `AvianReplicationMode::Position` + real gravity — avian's integrator is now the authority on Position.
- Two physics bundles: `_dynamic` for locally-simulated players (server + predicted), `_kinematic` for interpolated remote players so avian's local gravity doesn't fight lightyear's snapshots.

## Why

The old controller was the root cause of the rubber-banding we saw even after the leafwing migration. It wrote `Position` directly based on `SpatialQuery` results. Under lightyear's rollback/replay, `SpatialQuery` reads the **current** entity positions, not the replay-tick positions — so shape casts returned different results between original simulation and replay, making the controller non-idempotent. Visible result: rubber-banding.

With dynamic rigid bodies, motion is produced by `apply_force` / `apply_linear_impulse` into avian's integrator. The integrator consumes only `LinearVelocity` + `ComputedMass` + accumulated forces (all deterministic) and writes `Position` inside `PhysicsSchedule`. Because lightyear snapshots + restores those components during rollback, replay produces identical output each time.

## Key invariants preserved

- **leafwing + lag_compensation** (shipped in #8) — `ActionState` replication, rebroadcast, InterpolationDelay in input messages.
- **Lag-compensated hitscan** — `server_shoot_with_lag_comp` still uses `LagCompensationSpatialQuery` with the shooter's replicated `InterpolationDelay`.
- **Camera-yaw pre-rotation** — the client still rotates the Move axis to world space *before* `BufferClientInputs` captures ActionState, so the server never has to rotate by yaw itself.
- **Every gameplay system** — health, death, respawn (now also zeros avian velocities), inventory, loot drops, equippables, doors, mining, kill feed, wallet auth, HUD.

## Movement tunables (start, easy to retune)

| Const | Value | Meaning |
|---|---:|---|
| `MAX_SPEED` | 7.0 | horizontal ground speed cap (m/s) |
| `MAX_ACCELERATION` | 50.0 | max horizontal acceleration — snappier feel |
| `JUMP_IMPULSE` | 5.4 | vertical impulse; under -9.81 gravity lifts ~1.5 m |

## Test plan

- [x] `cargo build --release --bin server --bin client` — green
- [x] `cargo test --lib` — 3/3 pass
- [x] Server boots, spawns world, binds UDP, handles an inbound packet — no panics after 5s
- [ ] **@ryan** manual GUI smoke: WASD feels like intended; Space jumps; LMB/Q/E/G work; no ghost walls
- [ ] **@ryan** rollback/prediction test against prod server — confirm the rubber-banding is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)